### PR TITLE
Issue for profile picture overlapping solved

### DIFF
--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,7 +1,7 @@
 .profile {
     background-color: #133667 !important;
     text-align: center;
-    height: 320px;
+    padding-bottom: 20px;
     margin-bottom: 50px;
     h1 {
         font-size: 50px;
@@ -11,16 +11,23 @@
     
     img {
         border-radius: 50%;
-        max-width: 100%;
-        max-height: 100%;
+        max-width: 14%;
+        max-height: 14%;
         margin-left: auto;
         margin-right: auto;
         display: inline;        
         padding: 20px;
+
     }
-    
+    @media (max-width: 570px){
+        img{
+        display: inline-block;        
+        max-height: 40%;
+        max-width: 40%;
+
+        }
+    }
     .profile-picture {
         margin-bottom: 30px;
-        height: 200px;
     }
 }


### PR DESCRIPTION
Solved Issue #14 - Improve profile picture layout 

**Profile pictures does not overflow and website is responsive to adjust 2 profiles aligned together for mobile devices**

**Team**
1. [Anubhuti](https://github.com/Anu-123-gif)
2. [Rehan](https://github.com/Abusayid693)


![Screenshot 2021-10-05 at 4 37 36 PM](https://user-images.githubusercontent.com/35341198/136012139-769c3feb-b699-4692-bb6a-da9076fa7c0f.png)
## Please, go through these steps before you submit a PR.

- [ ] My Pod Leader knows I'm working on this Pull Request
- [ ] I've explained what the Pull Request is adding.
- [ ] I've explained why this is important.

